### PR TITLE
es_sink: Adding new output port for better file-based flowgraph shutdown.

### DIFF
--- a/grc/es_sink.xml
+++ b/grc/es_sink.xml
@@ -149,6 +149,11 @@
     <type>message</type>
     <optional>1</optional>
   </source>
+  <source>
+    <name>notify_handlers</name>
+    <type>message</type>
+    <optional>1</optional>
+  </source>
 
 
 </block>

--- a/lib/es_sink.cc
+++ b/lib/es_sink.cc
@@ -101,6 +101,13 @@ es_sink::es_sink (
     // for upstream schedulers
     message_port_register_out(pmt::mp("nconsumed"));
     message_port_register_out(pmt::mp("pdu_event"));
+    // notify_handlers is used to help shutdown in file-based flowgraphs.
+    // This is so that es_sink emits a pmt::mp("done") message to the downstream
+    // message block, and it can know to shutdown only when all of the blocks
+    // feeding it has shut down (and not just the trigger).
+    //
+    // This is a less relevant situation in realtime flowgraphs.
+    message_port_register_out(pmt::mp("notify_handlers"));
 
     // set up our special pdu handler
     event_queue->register_event_type("pdu_event");


### PR DESCRIPTION
Added new message port output ("notify_handlers") whose job is to connect es_sink to downstream eventstream handler blocks, so that they are now able to count the number of pmt::mp("done") messages they get to shutdown only after all upstream blocks are finished (in other words, the downstream blocks can now infer that es_sink is finished).  This is a critical feature for maximum-throughput file-based processing flowgraphs."