### PR TITLE
Adding es_handler_passthrough block...

### DIFF
--- a/grc/es_handler_passthrough.xml
+++ b/grc/es_handler_passthrough.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<block>
+  <name>Handler Passthrough</name>
+  <key>es_handler_passthrough</key>
+  <category>EVENTSTREAM</category>
+  <import>import es</import>
+  <make>es.es_make_handler_passthrough()</make>
+  
+  <sink>
+    <name>handle_event</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+
+  <source>
+    <name>events_out</name>
+    <type>message</type>
+    <optional>1</optional>
+  </source>
+
+  <doc>
+    This handler passes an event pmt through to the next block.
+  </doc>
+
+</block>

--- a/include/es/es_handler_passthrough.h
+++ b/include/es/es_handler_passthrough.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2011 Free Software Foundation, Inc.
+ * 
+ * This file is part of gr-eventstream
+ * 
+ * gr-eventstream is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-eventstream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-eventstream; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef EVENTSTREAM_HANDLER_PASSTHROUGH_H
+#define EVENTSTREAM_HANDLER_PASSTHROUGH_H
+
+#include <pmt/pmt.h>
+#include <gnuradio/block.h>
+
+
+
+using namespace pmt;
+
+#include <es/es_handler.h>
+
+
+class es_handler_passthrough : public es_handler {
+    public:
+        es_handler_passthrough();
+        //void handler( pmt_t msg, void* buf );
+
+        void handler( pmt_t msg, gr_vector_void_star buf );
+};
+
+es_handler_sptr es_make_handler_passthrough();
+
+#endif
+
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND eventstream_sources
     es_handler_print.cc
     es_handler_file.cc
     es_handler_pdu.cc
+    es_handler_passthrough.cc
     es_queue.cc
     es_sink.cc
     es_source.cc

--- a/lib/es_handler_passthrough.cc
+++ b/lib/es_handler_passthrough.cc
@@ -1,0 +1,45 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2011 Free Software Foundation, Inc.
+ * 
+ * This file is part of gr-eventstream
+ * 
+ * gr-eventstream is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * gr-eventstream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-eventstream; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <es/es.h>
+#include <es/es_handler_passthrough.h>
+#include <stdio.h>
+
+es_handler_sptr es_make_handler_passthrough(){
+    return es_handler_sptr(new es_handler_passthrough());
+}
+
+es_handler_passthrough::es_handler_passthrough() :
+    gr::sync_block ("es_handler_passthrough",
+            gr::io_signature::make(0,0,0),
+            gr::io_signature::make(0,0,0))
+{ 
+    message_port_register_out(pmt::mp("events_out"));
+}
+
+void es_handler_passthrough::handler( pmt_t msg, gr_vector_void_star buf ){
+    message_port_pub(pmt::mp("events_out"), msg);
+}
+
+
+
+

--- a/swig/es_swig.i
+++ b/swig/es_swig.i
@@ -39,6 +39,7 @@ namespace std {
 #include "es/es_handler_print.h"
 #include "es/es_handler_file.h"
 #include "es/es_handler_pdu.h"
+#include "es/es_handler_passthrough.h"
 #include "es/es_handler_flowgraph.h"
 #include "es/es_trigger.h"
 #include "es/es_trigger_edge_f.h"
@@ -51,6 +52,7 @@ namespace std {
 
 
 %include "es/es_handler_pdu.h"
+%include "es/es_handler_passthrough.h"
 %include "es_handler.i"
 %include "es_event.i"
 %include "es_source.i"


### PR DESCRIPTION
Adding es_handler_passthrough block (simply passes the event pmt through to the output port) to help improve flowgraph control/design in certain cases.