### PR TITLE
updated XMLs for new GRC block module format

### DIFF
--- a/grc/es_arb.xml
+++ b/grc/es_arb.xml
@@ -2,7 +2,7 @@
 <block>
   <name>EventStream Arbiter</name>
   <key>variable_es_arb</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <var_make>self.$(id) = $(id) = es.es_make_arbiter()</var_make>
   <make></make>

--- a/grc/es_emit_event.xml
+++ b/grc/es_emit_event.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Hier Stream Event - Emitted Event</name>
   <key>es_hier_event_emit</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es;
 import pmt;</import>
   <make>self.$(id) = $(id) = $evtname</make>

--- a/grc/es_handler_file.xml
+++ b/grc/es_handler_file.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Handler File</name>
   <key>es_handler_file</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.es_make_handler_file($dt, $path, $desc)</make>
   

--- a/grc/es_handler_passthrough.xml
+++ b/grc/es_handler_passthrough.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Handler Passthrough</name>
   <key>es_handler_passthrough</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.es_make_handler_passthrough()</make>
   

--- a/grc/es_handler_pdu.xml
+++ b/grc/es_handler_pdu.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Handler to PDU</name>
   <key>es_handler_pdu</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.es_make_handler_pdu($dt)</make>
   

--- a/grc/es_handler_print.xml
+++ b/grc/es_handler_print.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Handler Print</name>
   <key>es_handler_print</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.es_make_handler_print($dt)</make>
   

--- a/grc/es_patterned_interleaver.xml
+++ b/grc/es_patterned_interleaver.xml
@@ -2,7 +2,7 @@
 <block>
   <name>patterned_interleaver</name>
   <key>es_patterned_interleaver</key>
-  <category>es</category>
+  <category>[EVENTSTREAM]/es</category>
   <import>import es</import>
   <make>es.patterned_interleaver(items, itemsize, pattern)</make>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.

--- a/grc/es_sink.xml
+++ b/grc/es_sink.xml
@@ -2,7 +2,7 @@
 <block>
     <name>EventStream Sink</name>
     <key>es_sink</key>
-    <category>EVENTSTREAM</category>
+    <category>[EVENTSTREAM]</category>
     <import>import es</import>
     <make>es.sink($num_streams*[$type.size],$nthreads,$samplehistory,$eb.raw,$ss.raw,$cb.raw)</make>
 

--- a/grc/es_source.xml
+++ b/grc/es_source.xml
@@ -2,7 +2,7 @@
 <block>
   <name>EventStream Source</name>
   <key>es_source</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.source($num_streams*[$type.size], $nthreads, $eb.raw, $mm.raw)</make>
 

--- a/grc/es_trigger_edge_f.xml
+++ b/grc/es_trigger_edge_f.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Trigger Rising Edge Event</name>
   <key>es_trigger_edge_f</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.trigger_edge_f($thresh,$length,$lookback,$type.size,$guard)</make>
   

--- a/grc/es_trigger_sample_timer.xml
+++ b/grc/es_trigger_sample_timer.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Trigger Sample-Timer Event</name>
   <key>es_trigger_sample_timer</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>es.trigger_sample_timer($type.size, $period, $shift, $sched_dist, $length )</make>
   

--- a/grc/es_trigger_timer.xml
+++ b/grc/es_trigger_timer.xml
@@ -2,7 +2,7 @@
 <block>
   <name>Trigger System-Timer Event</name>
   <key>es_timer_trigger</key>
-  <category>EVENTSTREAM</category>
+  <category>[EVENTSTREAM]</category>
   <import>import es</import>
   <make>#slurp
 es.es_trigger_timer("TIMER_EXPIRED_EVENT", $length, $delay, $iterations); </make>

--- a/grc/patterned_interleaver.xml
+++ b/grc/patterned_interleaver.xml
@@ -2,7 +2,7 @@
 <block>
     <name>Patterned Interleaver</name>
     <key>patterned_interlaver</key>
-    <category>Stream Conversions</category>
+    <category>[EVENTSTREAM]/Stream Conversions</category>
     <import>import es, numpy</import>
     <make>es.patterned_interleaver($type.np, $ninputs, $pattern)</make>
 

--- a/grc/variable_es_evt.xml
+++ b/grc/variable_es_evt.xml
@@ -7,7 +7,7 @@
 <block>
 	<name>Event-Time Parameter</name>
 	<key>variable_es_evt</key>
-    <category>EVENTSTREAM</category>
+    <category>[EVENTSTREAM]</category>
 	<var_make>self.$(id) = $(id) = $value</var_make>
 	<make></make>
 	<param>


### PR DESCRIPTION
Puts all blocks into a module called "EVENTSTREAM" that works with the new GRC format. There are two blocks that are under sub modules called "es" and "Stream Conversions" and those were put as sub modules under the main module.